### PR TITLE
Set date to null instead of empty string

### DIFF
--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -18,10 +18,10 @@ function App() {
     maxDistance: '250',
     minAltitude: '0',
     maxAltitude: '4000',
-    date: '',
+    date: null,
     minSpaces: '1',
-    startDate: '',
-    endDate: '',
+    startDate: null,
+    endDate: null,
     maxHutDistance: 13
   });
   const [loading, setLoading] = useState(false);

--- a/frontend/src/MapComponent.js
+++ b/frontend/src/MapComponent.js
@@ -34,7 +34,6 @@ const ClickableMap = ({ handleMapClick }) => {
 };
 
 const getMarkerColor = (placesAvail, minSpaces) => {
-  minSpaces = minSpaces;
   if (placesAvail < 0) return 'grey';         // No data or unknown availability
   if (placesAvail >= minSpaces + 5) return 'green';   // Plenty of spaces
   if (placesAvail >= minSpaces) return 'orange';   // Limited availability
@@ -130,8 +129,8 @@ const MapComponent = ({ markers, routes, handleMapClick, minSpaces, radiusKm }) 
           key={index}
           positions={route.coordinates}
           color="purple"
-          weight={4}
-          opacity={0.8}
+          weight={5}
+          opacity={0.5}
           eventHandlers={{
             mouseover: (e) => {
               const layer = e.target;


### PR DESCRIPTION
Potential fix for #42 . The date-format-mismatch imo comes from the fact that some browsers (e.g. safari) automatically set a default date, while others don't. The default date has a different format. The problem is, I can't reproduce the issue locally because hutfinder.localhost does not work on Safari for me.
Setting the date to null might work for forcing Safari to keep it empty.